### PR TITLE
Require doctrine/persistance in root

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "symfony/dependency-injection": "^3.0||^4.0",
         "symfony/yaml": "^3.0||^4.0",
         "symfony/event-dispatcher": "^3.0||^4.0",
-        "doctrine/orm": "^2.0"
+        "doctrine/orm": "^2.0",
+        "doctrine/persistence": "^1.3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.5",


### PR DESCRIPTION
Require doctrine/persistence in root and set to ^1.3.3 since v2 has some breaking changes (namespace changes) which are directly used in this bundle. After merging this PR, a new version should be tagged.