### PR TITLE
Fixed deprecations, updated requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ sudo: false
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
+  - 7.4
 
 env:
   global:
@@ -15,12 +12,8 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.0
-    - php: 5.6
-    - php: 7.1
+    - php: 7.4
       env: DEPENDENCIES=beta
-  allow_failures:
-    - php: hhvm
 
 before_install:
   - if [ "$DEPENDENCIES" = "beta" ]; then composer config minimum-stability beta; fi;

--- a/Services/LifecycleEventsDispatcher.php
+++ b/Services/LifecycleEventsDispatcher.php
@@ -2,8 +2,8 @@
 
 namespace W3C\LifecycleEventsBundle\Services;
 
-use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
-use Doctrine\Common\Persistence\Event\PreUpdateEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\PreUpdateEventArgs;
 use Doctrine\Common\Util\ClassUtils;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use W3C\LifecycleEventsBundle\Annotation\Change;
@@ -110,7 +110,7 @@ class LifecycleEventsDispatcher
             $eventArgs  = $creation[1];
             $entity     = $eventArgs->getObject();
 
-            $this->dispatcher->dispatch($annotation->event, new $annotation->class($entity));
+            $this->dispatcher->dispatch(new $annotation->class($entity), $annotation->event);
         }
     }
 
@@ -129,7 +129,7 @@ class LifecycleEventsDispatcher
             $identifier = $deletion[2];
             $entity     = $eventArgs->getObject();
 
-            $this->dispatcher->dispatch($annotation->event, new $annotation->class($entity, $identifier));
+            $this->dispatcher->dispatch(new $annotation->class($entity, $identifier), $annotation->event);
         }
     }
 
@@ -145,8 +145,8 @@ class LifecycleEventsDispatcher
             list($annotation, $entity, $propertiesChanges, $collectionsChanges) = $update;
 
             $this->dispatcher->dispatch(
+                new $annotation->class($entity, $propertiesChanges, $collectionsChanges),
                 $annotation->event,
-                new $annotation->class($entity, $propertiesChanges, $collectionsChanges)
             );
         }
     }
@@ -163,8 +163,8 @@ class LifecycleEventsDispatcher
             list($annotation, $entity, $property, $oldValue, $newValue) = $propertyChange;
 
             $this->dispatcher->dispatch(
+                new $annotation->class($entity, $property, $oldValue, $newValue),
                 $annotation->event,
-                new $annotation->class($entity, $property, $oldValue, $newValue)
             );
         }
     }
@@ -187,8 +187,8 @@ class LifecycleEventsDispatcher
             }
 
             $this->dispatcher->dispatch(
+                new $annotation->class($entity, $property, $deleted, $added),
                 $annotation->event,
-                new $annotation->class($entity, $property, $deleted, $added)
             );
         }
     }
@@ -330,6 +330,6 @@ class LifecycleEventsDispatcher
      */
     public function preAutoDispatch()
     {
-        $this->dispatcher->dispatch('w3c.lifecycle.preAutoDispatch', new PreAutoDispatchEvent($this));
+        $this->dispatcher->dispatch(new PreAutoDispatchEvent($this), 'w3c.lifecycle.preAutoDispatch');
     }
 }

--- a/Tests/Annotation/ChangeTest.php
+++ b/Tests/Annotation/ChangeTest.php
@@ -24,7 +24,7 @@ class ChangeTest extends TestCase
      */
     private $reader;
 
-    public function setUp()
+    public function setUp() : void
     {
         $loader = require __DIR__ . '/../../vendor/autoload.php';
         AnnotationRegistry::registerLoader(array($loader, 'loadClass'));

--- a/Tests/Annotation/CreateTest.php
+++ b/Tests/Annotation/CreateTest.php
@@ -24,7 +24,7 @@ class CreateTest extends TestCase
      */
     private $reader;
 
-    public function setUp()
+    public function setUp() : void
     {
         $loader = require __DIR__ . '/../../vendor/autoload.php';
         AnnotationRegistry::registerLoader(array($loader, 'loadClass'));

--- a/Tests/Annotation/DeleteTest.php
+++ b/Tests/Annotation/DeleteTest.php
@@ -24,7 +24,7 @@ class DeleteTest extends TestCase
      */
     private $reader;
 
-    public function setUp()
+    public function setUp() : void
     {
         $loader = require __DIR__ . '/../../vendor/autoload.php';
         AnnotationRegistry::registerLoader(array($loader, 'loadClass'));

--- a/Tests/Annotation/IgnoreTest.php
+++ b/Tests/Annotation/IgnoreTest.php
@@ -22,7 +22,7 @@ class IgnoreTest extends TestCase
      */
     private $reader;
 
-    public function setUp()
+    public function setUp() : void
     {
         $loader = require __DIR__ . '/../../vendor/autoload.php';
         AnnotationRegistry::registerLoader(array($loader, 'loadClass'));

--- a/Tests/Annotation/UpdateTest.php
+++ b/Tests/Annotation/UpdateTest.php
@@ -24,7 +24,7 @@ class UpdateTest extends TestCase
      */
     private $reader;
 
-    public function setUp()
+    public function setUp() : void
     {
         $loader = require __DIR__ . '/../../vendor/autoload.php';
         AnnotationRegistry::registerLoader(array($loader, 'loadClass'));

--- a/Tests/Event/LifecycleUpdateEventTest.php
+++ b/Tests/Event/LifecycleUpdateEventTest.php
@@ -20,7 +20,7 @@ class LifecycleUpdateEventTest extends TestCase
      */
     private $event;
 
-    public function setUp()
+    public function setUp() : void
     {
         $entity                  = new User();
         $this->propertyChanges   = ['name' => ['old' => 'foo', 'new' => 'bar']];

--- a/Tests/EventListener/LifecycleEventsListenerInverseNoMonitorTest.php
+++ b/Tests/EventListener/LifecycleEventsListenerInverseNoMonitorTest.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use W3C\LifecycleEventsBundle\Annotation\Update;
 use W3C\LifecycleEventsBundle\EventListener\LifecycleEventsListener;
 use W3C\LifecycleEventsBundle\Services\AnnotationGetter;

--- a/Tests/EventListener/LifecycleEventsListenerInverseNoMonitorTest.php
+++ b/Tests/EventListener/LifecycleEventsListenerInverseNoMonitorTest.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\UnitOfWork;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use W3C\LifecycleEventsBundle\Annotation\Update;
 use W3C\LifecycleEventsBundle\EventListener\LifecycleEventsListener;
@@ -21,7 +22,7 @@ use W3C\LifecycleEventsBundle\Tests\Annotation\Fixtures\PersonNoMonitor;
 /**
  * @author Jean-Guilhem Rouel <jean-gui@w3.org>
  */
-class LifecycleEventsListenerInverseNoMonitorTest extends \PHPUnit_Framework_TestCase
+class LifecycleEventsListenerInverseNoMonitorTest extends TestCase
 {
     /**
      * @var LifecycleEventsListener
@@ -54,7 +55,7 @@ class LifecycleEventsListenerInverseNoMonitorTest extends \PHPUnit_Framework_Tes
     private $friend1;
     private $friend2;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/Tests/EventListener/LifecycleEventsListenerInverseTest.php
+++ b/Tests/EventListener/LifecycleEventsListenerInverseTest.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\UnitOfWork;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use W3C\LifecycleEventsBundle\Annotation\Change;
 use W3C\LifecycleEventsBundle\Annotation\Update;
@@ -22,7 +23,7 @@ use W3C\LifecycleEventsBundle\Tests\Annotation\Fixtures\Person;
 /**
  * @author Jean-Guilhem Rouel <jean-gui@w3.org>
  */
-class LifecycleEventsListenerInverseTest extends \PHPUnit_Framework_TestCase
+class LifecycleEventsListenerInverseTest extends TestCase
 {
     /**
      * @var LifecycleEventsListener
@@ -55,7 +56,7 @@ class LifecycleEventsListenerInverseTest extends \PHPUnit_Framework_TestCase
     private $friend1;
     private $friend2;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/Tests/EventListener/LifecycleEventsListenerInverseTest.php
+++ b/Tests/EventListener/LifecycleEventsListenerInverseTest.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use W3C\LifecycleEventsBundle\Annotation\Change;
 use W3C\LifecycleEventsBundle\Annotation\Update;
 use W3C\LifecycleEventsBundle\EventListener\LifecycleEventsListener;

--- a/Tests/EventListener/LifecycleEventsListenerTest.php
+++ b/Tests/EventListener/LifecycleEventsListenerTest.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use W3C\LifecycleEventsBundle\Annotation\Update;
 use W3C\LifecycleEventsBundle\EventListener\LifecycleEventsListener;
 use W3C\LifecycleEventsBundle\Services\AnnotationGetter;

--- a/Tests/EventListener/LifecycleEventsListenerTest.php
+++ b/Tests/EventListener/LifecycleEventsListenerTest.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\UnitOfWork;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use W3C\LifecycleEventsBundle\Annotation\Update;
 use W3C\LifecycleEventsBundle\EventListener\LifecycleEventsListener;
@@ -26,7 +27,7 @@ use W3C\LifecycleEventsBundle\Tests\EventListener\Fixtures\UserNoAnnotation;
 /**
  * @author Jean-Guilhem Rouel <jean-gui@w3.org>
  */
-class LifecycleEventsListenerTest extends \PHPUnit_Framework_TestCase
+class LifecycleEventsListenerTest extends TestCase
 {
     /**
      * @var LifecycleEventsListener
@@ -53,7 +54,7 @@ class LifecycleEventsListenerTest extends \PHPUnit_Framework_TestCase
      */
     private $classMetadata;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/Tests/EventListener/LifecyclePropertyEventsListenerTest.php
+++ b/Tests/EventListener/LifecyclePropertyEventsListenerTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\UnitOfWork;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use W3C\LifecycleEventsBundle\Annotation\Change;
 use W3C\LifecycleEventsBundle\Annotation\Update;
@@ -26,7 +27,7 @@ use W3C\LifecycleEventsBundle\Tests\EventListener\Fixtures\UserNoAnnotation;
 /**
  * @author Jean-Guilhem Rouel <jean-gui@w3.org>
  */
-class LifecyclePropertyEventsListenerTest extends \PHPUnit_Framework_TestCase
+class LifecyclePropertyEventsListenerTest extends TestCase
 {
     /**
      * @var LifecycleEventsListener
@@ -58,7 +59,7 @@ class LifecyclePropertyEventsListenerTest extends \PHPUnit_Framework_TestCase
      */
     private $classMetadata;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/Tests/EventListener/LifecyclePropertyEventsListenerTest.php
+++ b/Tests/EventListener/LifecyclePropertyEventsListenerTest.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use W3C\LifecycleEventsBundle\Annotation\Change;
 use W3C\LifecycleEventsBundle\Annotation\Update;
 use W3C\LifecycleEventsBundle\EventListener\LifecycleEventsListener;

--- a/Tests/EventListener/PostFlushListenerTest.php
+++ b/Tests/EventListener/PostFlushListenerTest.php
@@ -22,7 +22,7 @@ class PostFlushListenerTest extends TestCase
      */
     private $event;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/Tests/Services/AnnotationGetterTest.php
+++ b/Tests/Services/AnnotationGetterTest.php
@@ -27,7 +27,7 @@ class AnnotationGetterTest extends TestCase
      */
     private $classMetadata;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/Tests/Services/AnnotationGetterTest.php
+++ b/Tests/Services/AnnotationGetterTest.php
@@ -5,7 +5,7 @@ namespace W3C\LifecycleEventsBundle\Tests\Services;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use W3C\LifecycleEventsBundle\Annotation\Change;
 use W3C\LifecycleEventsBundle\Annotation\Create;
 use W3C\LifecycleEventsBundle\Annotation\Update;

--- a/Tests/Services/LifecycleEventsDispatcherTest.php
+++ b/Tests/Services/LifecycleEventsDispatcherTest.php
@@ -2,8 +2,8 @@
 
 namespace W3C\LifecycleEventsBundle\Tests\Services;
 
-use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Persistence\ObjectManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use W3C\LifecycleEventsBundle\Tests\Services\Fixtures\MySubscriber;
 use PHPUnit\Framework\TestCase;
@@ -53,7 +53,7 @@ class LifecycleEventsDispatcherTest extends TestCase
      */
     private $classMetadata;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 
@@ -86,7 +86,7 @@ class LifecycleEventsDispatcherTest extends TestCase
 
         $this->sfDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(LifecycleEvents::CREATED, $expectedEvent)
+            ->with($expectedEvent, LifecycleEvents::CREATED)
         ;
 
         $this->dispatcher->dispatchEvents();
@@ -130,7 +130,7 @@ class LifecycleEventsDispatcherTest extends TestCase
         $expectedEvent = new $annotation->class($user);
         $this->sfDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with($annotation->event, $expectedEvent);
+            ->with($expectedEvent, $annotation->event);
 
         $this->dispatcher->dispatchEvents();
     }
@@ -156,7 +156,7 @@ class LifecycleEventsDispatcherTest extends TestCase
         $expectedEvent = new LifecycleDeletionEvent($user, ['name' => 'toto']);
         $this->sfDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(LifecycleEvents::DELETED, $expectedEvent);
+            ->with($expectedEvent, LifecycleEvents::DELETED);
 
         $this->dispatcher->dispatchEvents();
     }
@@ -216,7 +216,7 @@ class LifecycleEventsDispatcherTest extends TestCase
         $expectedEvent = new $annotation->class($user, ['name' => 'toto']);
         $this->sfDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with($annotation->event, $this->equalTo($expectedEvent));
+            ->with($this->equalTo($expectedEvent), $annotation->event);
 
         $this->dispatcher->dispatchEvents();
     }
@@ -237,7 +237,7 @@ class LifecycleEventsDispatcherTest extends TestCase
         $expectedEvent = new LifecycleUpdateEvent($user, ['name' => ['foo', 'bar']], []);
         $this->sfDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(LifecycleEvents::UPDATED, $expectedEvent);
+            ->with($expectedEvent, LifecycleEvents::UPDATED);
 
         $this->dispatcher->dispatchEvents();
     }
@@ -289,7 +289,7 @@ class LifecycleEventsDispatcherTest extends TestCase
         $expectedEvent = new $annotation->class($user, ['name' => ['foo', 'bar']], []);
         $this->sfDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with($annotation->event, $expectedEvent);
+            ->with($expectedEvent, $annotation->event);
 
         $this->dispatcher->dispatchEvents();
     }
@@ -311,7 +311,7 @@ class LifecycleEventsDispatcherTest extends TestCase
         $expectedEvent = new LifecyclePropertyChangedEvent($user, 'name', 'foo', 'bar');
         $this->sfDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(LifecycleEvents::PROPERTY_CHANGED, $expectedEvent);
+            ->with($expectedEvent, LifecycleEvents::PROPERTY_CHANGED);
 
         $this->dispatcher->dispatchEvents();
     }
@@ -365,7 +365,7 @@ class LifecycleEventsDispatcherTest extends TestCase
         $expectedEvent = new $annotation->class($user, 'name', 'foo', 'bar');
         $this->sfDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with($annotation->event, $expectedEvent);
+            ->with($expectedEvent, $annotation->event);
 
         $this->dispatcher->dispatchEvents();
     }
@@ -388,7 +388,7 @@ class LifecycleEventsDispatcherTest extends TestCase
         $expectedEvent = new LifecycleCollectionChangedEvent($user, 'friends', $deleted, $inserted);
         $this->sfDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(LifecycleEvents::COLLECTION_CHANGED, $expectedEvent);
+            ->with($expectedEvent, LifecycleEvents::COLLECTION_CHANGED);
 
         $this->dispatcher->dispatchEvents();
     }
@@ -446,7 +446,7 @@ class LifecycleEventsDispatcherTest extends TestCase
         $expectedEvent = new $annotation->class($user, 'friends', $deleted, $inserted);
         $this->sfDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with($annotation->event, $expectedEvent);
+            ->with($expectedEvent, $annotation->event);
 
         $this->dispatcher->dispatchEvents();
     }
@@ -455,7 +455,7 @@ class LifecycleEventsDispatcherTest extends TestCase
     {
         $this->sfDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with('w3c.lifecycle.preAutoDispatch', new PreAutoDispatchEvent($this->dispatcher));
+            ->with(new PreAutoDispatchEvent($this->dispatcher),'w3c.lifecycle.preAutoDispatch');
 
         $this->dispatcher->preAutoDispatch();
     }

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,17 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
-        "symfony/http-kernel": "^3.0||^4.0",
-        "symfony/config": "^3.0||^4.0",
-        "symfony/dependency-injection": "^3.0||^4.0",
-        "symfony/yaml": "^3.0||^4.0",
-        "symfony/event-dispatcher": "^3.0||^4.0",
-        "doctrine/orm": "^2.0"
+        "php": ">=7.4",
+        "symfony/http-kernel": "^4.3",
+        "symfony/config": "^4.3",
+        "symfony/dependency-injection": "^4.3",
+        "symfony/yaml": "^4.3",
+        "symfony/event-dispatcher": "^4.3",
+        "doctrine/orm": "^2.0",
+        "doctrine/persistence": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.5",
+        "phpunit/phpunit": "^8.2.3",
         "symfony/phpunit-bridge": "^3.1",
         "satooshi/php-coveralls": "^2.0"
     },


### PR DESCRIPTION
Fixed deprecations and updated the requirements accordingly:
- doctrine/persistence changed the namespaces (2.0+)
- symfony changed the order of the dispatch parameters (4.3+)
- doctrine/persistence ^2.0 requires PHP 7.4
- PHP 7.4 requires phpunit ^8.2.3 to avoid deprecation notices.

I know having PHP 7.4 as a requirement is pretty high, but the old versions will still have the full functionality.
