### PR TITLE
Symfony 8 support

### DIFF
--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.2,8.5]
+        php-version: [8.2,8.4,8.5]
         deps: ["low","default"]
     env:
       XDEBUG_MODE: coverage

--- a/EventListener/LifecycleEventsListener.php
+++ b/EventListener/LifecycleEventsListener.php
@@ -63,11 +63,11 @@ class LifecycleEventsListener
         foreach ($classMetadata->getAssociationMappings() as $property => $associationMapping) {
             if (!$classMetadata->isAssociationInverseSide($property)) {
                 if ($classMetadata->isSingleValuedAssociation($property)) {
-                    $inverse = $classMetadata->reflFields[$property]->getValue($entity);
+                    $inverse = $classMetadata->propertyAccessors[$property]->getValue($entity);
                     $change  = ['old' => null, 'new' => $inverse];
                     $this->propertyUpdateInverse($args, $class, $property, $change, $entity);
                 } elseif ($classMetadata->isCollectionValuedAssociation($property)) {
-                    $inverse = $classMetadata->reflFields[$property]->getValue($entity);
+                    $inverse = $classMetadata->propertyAccessors[$property]->getValue($entity);
                     if ($inverse) {
                         $change = ['deleted' => [], 'inserted' => $inverse->toArray()];
                         $this->collectionUpdateInverse($args, $class, $property, $change, $entity);
@@ -113,11 +113,11 @@ class LifecycleEventsListener
         foreach ($classMetadata->getAssociationMappings() as $property => $associationMapping) {
             if (!$classMetadata->isAssociationInverseSide($property)) {
                 if ($classMetadata->isSingleValuedAssociation($property)) {
-                    $inverse = $classMetadata->reflFields[$property]->getValue($entity);
+                    $inverse = $classMetadata->propertyAccessors[$property]->getValue($entity);
                     $change  = ['old' => $inverse, 'new' => null];
                     $this->propertyUpdateInverse($args, $class, $property, $change, $entity);
                 } elseif ($classMetadata->isCollectionValuedAssociation($property)) {
-                    $inverse = $classMetadata->reflFields[$property]->getValue($entity);
+                    $inverse = $classMetadata->propertyAccessors[$property]->getValue($entity);
                     if ($inverse) {
                         $change = ['deleted' => $inverse->toArray(), 'inserted' => []];
                         $this->collectionUpdateInverse($args, $class, $property, $change, $entity);

--- a/Services/AttributeGetter.php
+++ b/Services/AttributeGetter.php
@@ -46,7 +46,7 @@ class AttributeGetter
     public function getPropertyAttribute(ClassMetadata $classMetadata, string $field, string $attributeClass): ?object
     {
 
-        $reflProperty = $classMetadata->getReflectionProperty($field);
+        $reflProperty = $classMetadata->getPropertyAccessor($field)?->getUnderlyingReflector();
 
         if ($reflProperty) {
             $attributes = $reflProperty->getAttributes($attributeClass);

--- a/Tests/EventListener/LifecycleEventsListenerInverseNoMonitorTest.php
+++ b/Tests/EventListener/LifecycleEventsListenerInverseNoMonitorTest.php
@@ -16,10 +16,11 @@ use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
 use Doctrine\ORM\Mapping\OneToManyAssociationMapping;
 use Doctrine\ORM\Mapping\OneToOneInverseSideMapping;
 use Doctrine\ORM\Mapping\OneToOneOwningSideMapping;
+use Doctrine\ORM\Mapping\PropertyAccessors\PropertyAccessorFactory;
+use Doctrine\ORM\Mapping\PropertyAccessors\RawValuePropertyAccessor;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
 use W3C\LifecycleEventsBundle\Attribute\Update;
 use W3C\LifecycleEventsBundle\EventListener\LifecycleEventsListener;
 use W3C\LifecycleEventsBundle\Services\AttributeGetter;
@@ -138,15 +139,14 @@ class LifecycleEventsListenerInverseNoMonitorTest extends TestCase
         });
 
         $this->classMetadata
-            ->method('getReflectionProperty')
+            ->method('getPropertyAccessor')
             ->willReturnCallback(function () {
                 $field = func_get_arg(0);
-                return new \ReflectionProperty(PersonNoMonitor::class, $field);
+                return PropertyAccessorFactory::createPropertyAccessor(PersonNoMonitor::class, $field);
         });
 
         foreach (array_keys($this->mappings) as $field) {
-            $this->classMetadata->reflFields[$field] = $this
-                ->getMockBuilder(\ReflectionProperty::class)
+            $this->classMetadata->propertyAccessors[$field] = $this->getMockBuilder(RawValuePropertyAccessor::class)
                 ->disableOriginalConstructor()
                 ->onlyMethods(['getValue'])
                 ->getMock();
@@ -204,7 +204,7 @@ class LifecycleEventsListenerInverseNoMonitorTest extends TestCase
             ->with($this->person::class)
             ->willReturn($this->classMetadata);
 
-        $this->classMetadata->reflFields['mentor']
+        $this->classMetadata->propertyAccessors['mentor']
             ->method('getValue')
             ->willReturn($this->mentor);
 
@@ -227,7 +227,7 @@ class LifecycleEventsListenerInverseNoMonitorTest extends TestCase
             ->with($this->person::class)
             ->willReturn($this->classMetadata);
 
-        $this->classMetadata->reflFields['mentor']
+        $this->classMetadata->propertyAccessors['mentor']
             ->method('getValue')
             ->willReturn($this->mentor);
 
@@ -256,7 +256,7 @@ class LifecycleEventsListenerInverseNoMonitorTest extends TestCase
             ->with($this->person::class)
             ->willReturn($this->classMetadata);
 
-        $this->classMetadata->reflFields['mentor']
+        $this->classMetadata->propertyAccessors['mentor']
             ->method('getValue')
             ->willReturn($this->mentor);
 
@@ -306,7 +306,7 @@ class LifecycleEventsListenerInverseNoMonitorTest extends TestCase
             ->with($this->person::class)
             ->willReturn($this->classMetadata);
 
-        $this->classMetadata->reflFields['father']
+        $this->classMetadata->propertyAccessors['father']
             ->method('getValue')
             ->willReturn($this->father);
 
@@ -329,7 +329,7 @@ class LifecycleEventsListenerInverseNoMonitorTest extends TestCase
             ->with($this->person::class)
             ->willReturn($this->classMetadata);
 
-        $this->classMetadata->reflFields['father']
+        $this->classMetadata->propertyAccessors['father']
             ->method('getValue')
             ->willReturn($this->mentor);
 
@@ -404,7 +404,7 @@ class LifecycleEventsListenerInverseNoMonitorTest extends TestCase
             ->with($this->person::class)
             ->willReturn($this->classMetadata);
 
-        $this->classMetadata->reflFields['friends']
+        $this->classMetadata->propertyAccessors['friends']
             ->method('getValue')
             ->willReturn(new ArrayCollection([$this->friend1, $this->friend2]));
 
@@ -427,7 +427,7 @@ class LifecycleEventsListenerInverseNoMonitorTest extends TestCase
             ->with($this->person::class)
             ->willReturn($this->classMetadata);
 
-        $this->classMetadata->reflFields['friends']
+        $this->classMetadata->propertyAccessors['friends']
             ->method('getValue')
             ->willReturn(new ArrayCollection([$this->friend1, $this->friend2]));
 

--- a/Tests/EventListener/LifecycleEventsListenerInverseTest.php
+++ b/Tests/EventListener/LifecycleEventsListenerInverseTest.php
@@ -16,6 +16,8 @@ use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
 use Doctrine\ORM\Mapping\OneToManyAssociationMapping;
 use Doctrine\ORM\Mapping\OneToOneInverseSideMapping;
 use Doctrine\ORM\Mapping\OneToOneOwningSideMapping;
+use Doctrine\ORM\Mapping\PropertyAccessors\PropertyAccessorFactory;
+use Doctrine\ORM\Mapping\PropertyAccessors\RawValuePropertyAccessor;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\TestCase;
@@ -139,15 +141,17 @@ class LifecycleEventsListenerInverseTest extends TestCase
         });
 
         $this->classMetadata
-            ->method('getReflectionProperty')
+            ->method('getPropertyAccessor')
             ->willReturnCallback(function () {
                 $field = func_get_arg(0);
-                return new \ReflectionProperty(Person::class, $field);
+                return PropertyAccessorFactory::createPropertyAccessor(Person::class, $field);
         });
 
         foreach (array_keys($this->mappings) as $field) {
-            $this->classMetadata->reflFields[$field] = $this
-                ->getMockBuilder(\ReflectionProperty::class)
+            $this->classMetadata->propertyAccessors[$field] = $this->getMockBuilder(RawValuePropertyAccessor::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+            $this->classMetadata->propertyAccessors[$field] = $this->getMockBuilder(RawValuePropertyAccessor::class)
                 ->disableOriginalConstructor()
                 ->onlyMethods(['getValue'])
                 ->getMock();
@@ -209,7 +213,7 @@ class LifecycleEventsListenerInverseTest extends TestCase
             ->method('getName')
             ->willReturn($this->person::class);
 
-        $this->classMetadata->reflFields['mentor']
+        $this->classMetadata->propertyAccessors['mentor']
             ->method('getValue')
             ->willReturn($this->mentor);
 
@@ -252,7 +256,7 @@ class LifecycleEventsListenerInverseTest extends TestCase
             ->method('getName')
             ->willReturn($this->person::class);
 
-        $this->classMetadata->reflFields['mentor']
+        $this->classMetadata->propertyAccessors['mentor']
             ->method('getValue')
             ->willReturn($this->mentor);
 
@@ -301,7 +305,7 @@ class LifecycleEventsListenerInverseTest extends TestCase
             ->method('getName')
             ->willReturn($this->person::class);
 
-        $this->classMetadata->reflFields['mentor']
+        $this->classMetadata->propertyAccessors['mentor']
             ->method('getValue')
             ->willReturn($this->mentor);
 
@@ -381,7 +385,7 @@ class LifecycleEventsListenerInverseTest extends TestCase
             ->method('getName')
             ->willReturn($this->person::class);
 
-        $this->classMetadata->reflFields['father']
+        $this->classMetadata->propertyAccessors['father']
             ->method('getValue')
             ->willReturn($this->father);
 
@@ -423,7 +427,7 @@ class LifecycleEventsListenerInverseTest extends TestCase
             ->method('getName')
             ->willReturn($this->person::class);
 
-        $this->classMetadata->reflFields['father']
+        $this->classMetadata->propertyAccessors['father']
             ->method('getValue')
             ->willReturn($this->father);
 
@@ -566,7 +570,7 @@ class LifecycleEventsListenerInverseTest extends TestCase
             ->method('getName')
             ->willReturn($this->person::class);
 
-        $this->classMetadata->reflFields['friends']
+        $this->classMetadata->propertyAccessors['friends']
             ->method('getValue')
             ->willReturn(new ArrayCollection([$this->friend1, $this->friend2]));
 
@@ -636,7 +640,7 @@ class LifecycleEventsListenerInverseTest extends TestCase
             ->method('getName')
             ->willReturn($this->person::class);
 
-        $this->classMetadata->reflFields['friends']
+        $this->classMetadata->propertyAccessors['friends']
             ->method('getValue')
             ->willReturn(new ArrayCollection([$this->friend1, $this->friend2]));
 

--- a/Tests/EventListener/LifecycleEventsListenerTest.php
+++ b/Tests/EventListener/LifecycleEventsListenerTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Event\PreRemoveEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\OneToManyAssociationMapping;
+use Doctrine\ORM\Mapping\PropertyAccessors\PropertyAccessorFactory;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\TestCase;
@@ -219,9 +220,9 @@ class LifecycleEventsListenerTest extends TestCase
             ->willReturn($user::class);
 
         $this->classMetadata
-            ->method('getReflectionProperty')
+            ->method('getPropertyAccessor')
             ->with('name')
-            ->willReturn(new \ReflectionProperty($user, 'name'));
+            ->willReturn(PropertyAccessorFactory::createPropertyAccessor($user::class, 'name'));
 
         $this->dispatcher->expects($this->once())
             ->method('addUpdate')
@@ -249,9 +250,9 @@ class LifecycleEventsListenerTest extends TestCase
             ->willReturn($user::class);
 
         $this->classMetadata
-            ->method('getReflectionProperty')
+            ->method('getPropertyAccessor')
             ->with('name')
-            ->willReturn(new \ReflectionProperty($user, 'name'));
+            ->willReturn(PropertyAccessorFactory::createPropertyAccessor($user::class, 'name'));
 
         $this->dispatcher->expects($this->once())
             ->method('addUpdate')
@@ -300,9 +301,9 @@ class LifecycleEventsListenerTest extends TestCase
             ->willReturn($user::class);
 
         $this->classMetadata
-            ->method('getReflectionProperty')
+            ->method('getPropertyAccessor')
             ->with('friends')
-            ->willReturn(new \ReflectionProperty($user, 'friends'));
+            ->willReturn(PropertyAccessorFactory::createPropertyAccessor($user::class, 'friends'));
 
         $this->dispatcher->expects($this->once())
             ->method('addUpdate')
@@ -364,9 +365,9 @@ class LifecycleEventsListenerTest extends TestCase
             ->willReturn($user::class);
 
         $this->classMetadata
-            ->method('getReflectionProperty')
+            ->method('getPropertyAccessor')
             ->with('friends')
-            ->willReturn(new \ReflectionProperty($user, 'friends'));
+            ->willReturn(PropertyAccessorFactory::createPropertyAccessor($user::class, 'friends'));
 
         $this->listener->preUpdate($event);
     }

--- a/Tests/EventListener/LifecyclePropertyEventsListenerTest.php
+++ b/Tests/EventListener/LifecyclePropertyEventsListenerTest.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\OneToManyAssociationMapping;
+use Doctrine\ORM\Mapping\PropertyAccessors\PropertyAccessorFactory;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\TestCase;
@@ -106,9 +107,9 @@ class LifecyclePropertyEventsListenerTest extends TestCase
             ->willReturn($user::class);
 
         $this->classMetadata
-            ->method('getReflectionProperty')
+            ->method('getPropertyAccessor')
             ->with('name')
-            ->willReturn(new \ReflectionProperty($user, 'name'));
+            ->willReturn(PropertyAccessorFactory::createPropertyAccessor($user::class, 'name'));
 
         $this->dispatcher->expects($this->once())
             ->method('addPropertyChange')
@@ -123,7 +124,7 @@ class LifecyclePropertyEventsListenerTest extends TestCase
         $changeSet = [];
         $event     = new PreUpdateEventArgs($user, $this->manager, $changeSet);
 
-        $reflection = new \ReflectionProperty(get_class($user), 'name');
+        $reflection = PropertyAccessorFactory::createPropertyAccessor($user::class, 'name')->getUnderlyingReflector();
         $attribute = $reflection->getAttributes(Change::class)[0]->newInstance();
 
         $deleted = [new User(), new User()];
@@ -144,9 +145,9 @@ class LifecyclePropertyEventsListenerTest extends TestCase
             ->willReturn($user::class);
 
         $this->classMetadata
-            ->method('getReflectionProperty')
+            ->method('getPropertyAccessor')
             ->with('friends')
-            ->willReturn(new \ReflectionProperty($user, 'friends'));
+            ->willReturn(PropertyAccessorFactory::createPropertyAccessor($user::class, 'friends'));
 
         $this->dispatcher->expects($this->once())
             ->method('addCollectionChange')
@@ -215,9 +216,9 @@ class LifecyclePropertyEventsListenerTest extends TestCase
             ->willReturn($user::class);
 
         $this->classMetadata
-            ->method('getReflectionProperty')
+            ->method('getPropertyAccessor')
             ->with('friends')
-            ->willReturn(new \ReflectionProperty($user, 'friends'));
+            ->willReturn(PropertyAccessorFactory::createPropertyAccessor($user::class, 'friends'));
 
         $this->dispatcher->expects($this->never())
             ->method('addCollectionChange');

--- a/Tests/Services/AttributeGetterTest.php
+++ b/Tests/Services/AttributeGetterTest.php
@@ -3,6 +3,7 @@
 namespace W3C\LifecycleEventsBundle\Tests\Services;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\PropertyAccessors\PropertyAccessorFactory;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use W3C\LifecycleEventsBundle\Attribute\Change;
@@ -60,9 +61,9 @@ class AttributeGetterTest extends TestCase
         $user = new UserChange();
 
         $this->classMetadata
-            ->method('getReflectionProperty')
+            ->method('getPropertyAccessor')
             ->with('name')
-            ->willReturn(new \ReflectionProperty($user, 'name'));
+            ->willReturn(PropertyAccessorFactory::createPropertyAccessor($user::class, 'name'));
 
         $attribute = $this->attributeGetter->getPropertyAttribute($this->classMetadata, 'name', Change::class);
 
@@ -74,9 +75,9 @@ class AttributeGetterTest extends TestCase
         $user = new UserChange();
 
         $this->classMetadata
-            ->method('getReflectionProperty')
+            ->method('getPropertyAccessor')
             ->with('email')
-            ->willReturn(new \ReflectionProperty($user, 'email'));
+            ->willReturn(PropertyAccessorFactory::createPropertyAccessor($user::class, 'email'));
 
         $attribute = $this->attributeGetter->getPropertyAttribute($this->classMetadata, 'email', Change::class);
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/yaml": "^7.0|^8.0",
         "symfony/event-dispatcher": "^7.0|^8.0",
         "doctrine/orm": "^3.4",
-        "doctrine/persistence": "^3.0"
+        "doctrine/persistence": "^3.0|^4.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/dependency-injection": "^7.0|^8.0",
         "symfony/yaml": "^7.0|^8.0",
         "symfony/event-dispatcher": "^7.0|^8.0",
-        "doctrine/orm": "^3.0",
+        "doctrine/orm": "^3.4",
         "doctrine/persistence": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds Symfony 8 support.

The main change is that the property `ClassMetadata::reflFields` is now deprecated so I've changed it to `ClassMetadata::propertyAccessors`. This change forced me to fix a lot of tests as well.

Also worth noting, I did not upgrade PHPUnit because we are using some features related to mocks that have been removed from more recent versions without providing alternatives (see https://github.com/sebastianbergmann/phpunit/issues/5307 for example).